### PR TITLE
Disable inclusion of stripe lib in fastboot

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
-'use strict';
+'contains('Test')use strict';
 
 module.exports = {
   name: 'ember-cli-stripe-patched',
-  
+
   contentFor: function(type) {
-    if (type === 'body') {
+    if (type === 'body'  && process.env.EMBER_CLI_FASTBOOT !== 'true') {
       return '<script src="https://checkout.stripe.com/checkout.js"></script>';
     }
   },


### PR DESCRIPTION
This addon is throwing errors and warnings within fastboot, this should help but consumers of this addon should be also checking via fastboot service and not rendering the component.
